### PR TITLE
[Unit Tests] SparseMethodContext

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseMethodContextTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseMethodContextTests.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.mapper;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.NAME_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.PARAMETERS_FIELD;
+
+public class SparseMethodContextTests extends AbstractSparseTestBase {
+
+    @Mock
+    private StreamInput mockStreamInput;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+    }
+
+    public void testParseWithEmptyName() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "");
+        input.put(PARAMETERS_FIELD, new HashMap<>());
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { SparseMethodContext.parse(input); });
+        assertEquals("name needs to be set", exception.getMessage());
+    }
+
+    public void testParseWithInvalidParameterKey() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "testMethod");
+        input.put("invalidKey", "someValue");
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { SparseMethodContext.parse(input); });
+        assertEquals("Invalid parameter: invalidKey", exception.getMessage());
+    }
+
+    public void testParseWithInvalidParametersType() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "testMethod");
+        input.put(PARAMETERS_FIELD, "Not a map");
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { SparseMethodContext.parse(input); });
+        assertEquals("Unable to parse parameters for main method component", exception.getMessage());
+    }
+
+    public void testParseWithNonMapInput() {
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { SparseMethodContext.parse("Not a map"); });
+        assertEquals("Unable to parse mapping into SparseMethodContext. Object not of type \"Map\"", exception.getMessage());
+    }
+
+    public void testSparseMethodContextConstructorWithIOException() throws IOException {
+        StreamInput mockInput = mock(StreamInput.class);
+        when(mockInput.readString()).thenThrow(new IOException("Simulated IO error"));
+
+        expectThrows(IOException.class, () -> { new SparseMethodContext(mockInput); });
+    }
+
+    public void testSparseMethodConstructorWithStreamInput() throws IOException {
+        StreamInput mockStreamInput = mock(StreamInput.class);
+        when(mockStreamInput.readString()).thenReturn("testMethod");
+
+        SparseMethodContext sparseMethodContext = new SparseMethodContext(mockStreamInput);
+
+        assertEquals("testMethod", sparseMethodContext.getName());
+        assertNotNull(sparseMethodContext.getMethodComponentContext());
+    }
+
+    public void testParseInvalidParameterAndEmptyName() {
+        Map<String, Object> inputMap = new HashMap<>();
+        inputMap.put("invalid_key", "some_value");
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { SparseMethodContext.parse(inputMap); });
+        assertEquals("Invalid parameter: invalid_key", exception.getMessage());
+    }
+
+    public void testParseNullParameters() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "testMethod");
+        input.put(PARAMETERS_FIELD, null);
+
+        SparseMethodContext result = SparseMethodContext.parse(input);
+
+        assertEquals("testMethod", result.getName());
+        assertTrue(result.getMethodComponentContext().getParameters().isEmpty());
+    }
+
+    public void testParseValidNameOnly() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "testMethod");
+
+        SparseMethodContext result = SparseMethodContext.parse(input);
+
+        assertEquals("testMethod", result.getName());
+        assertEquals(new HashMap<>(), result.getMethodComponentContext().getParameters());
+    }
+
+    public void testParseWithNestedMethodComponentContext() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "test_method");
+
+        Map<String, Object> parameters = new HashMap<>();
+        Map<String, Object> nestedMap = new HashMap<>();
+        nestedMap.put(NAME_FIELD, "nested_method");
+        nestedMap.put(PARAMETERS_FIELD, new HashMap<>());
+        parameters.put("nested_param", nestedMap);
+        input.put(PARAMETERS_FIELD, parameters);
+
+        SparseMethodContext result = SparseMethodContext.parse(input);
+
+        assertNotNull(result);
+        assertEquals("test_method", result.getName());
+        assertNotNull(result.getMethodComponentContext());
+        assertEquals("test_method", result.getMethodComponentContext().getName());
+
+        Map<String, Object> resultParameters = result.getMethodComponentContext().getParameters();
+        assertNotNull(resultParameters);
+        assertEquals(1, resultParameters.size());
+        assertTrue(resultParameters.get("nested_param") instanceof MethodComponentContext);
+
+        MethodComponentContext nestedContext = (MethodComponentContext) resultParameters.get("nested_param");
+        assertEquals("nested_method", nestedContext.getName());
+        assertNotNull(nestedContext.getParameters());
+        assertTrue(nestedContext.getParameters().isEmpty());
+    }
+
+    public void testToXContentSerializesCorrectly() throws IOException {
+        String name = "test_method";
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", "value1");
+        parameters.put("param2", 42);
+
+        MethodComponentContext methodComponentContext = new MethodComponentContext(name, parameters);
+        SparseMethodContext sparseMethodContext = new SparseMethodContext(name, methodComponentContext);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        sparseMethodContext.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        String result = builder.toString();
+        assertTrue(result.contains("test_method"));
+        assertTrue(result.contains("param1"));
+        assertTrue(result.contains("value1"));
+        assertTrue(result.contains("param2"));
+        assertTrue(result.contains("42"));
+    }
+
+    public void testWriteToAndReadFrom() throws IOException {
+        String name = "testMethod";
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", "value1");
+        parameters.put("param2", 42);
+        MethodComponentContext methodComponentContext = new MethodComponentContext(name, parameters);
+        SparseMethodContext sparseMethodContext = new SparseMethodContext(name, methodComponentContext);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        sparseMethodContext.writeTo(out);
+
+        BytesReference bytesRef = out.bytes();
+        StreamInput in = bytesRef.streamInput();
+        SparseMethodContext readContext = new SparseMethodContext(in);
+
+        assertEquals(name, readContext.getName());
+        assertEquals(methodComponentContext, readContext.getMethodComponentContext());
+    }
+
+    public void testParseWithNonMapParameterValues() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "testMethod");
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("stringParam", "stringValue");
+        parameters.put("intParam", 42);
+        parameters.put("boolParam", true);
+        input.put(PARAMETERS_FIELD, parameters);
+
+        SparseMethodContext result = SparseMethodContext.parse(input);
+
+        assertEquals("testMethod", result.getName());
+        Map<String, Object> resultParams = result.getMethodComponentContext().getParameters();
+        assertEquals("stringValue", resultParams.get("stringParam"));
+        assertEquals(42, resultParams.get("intParam"));
+        assertEquals(true, resultParams.get("boolParam"));
+    }
+}


### PR DESCRIPTION
### Description
This PR contributed unit tests to `SparseMethodContext` class under `org.opensearch.neuralsearch.sparse.mapper`. It has 100% coverage on this high dependency class.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
