### PR TITLE
[Unit Tests] SparseTokensFieldMapper After Rebase

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldMapperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldMapperTests.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.mapper;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.mockito.MockitoAnnotations;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.testsPrepareUtils;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.ToXContent;
+
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.ALGO_TRIGGER_DOC_COUNT_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.NAME_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.PARAMETERS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SEISMIC;
+
+public class SparseTokensFieldMapperTests extends AbstractSparseTestBase {
+    private SparseTokensFieldMapper.Builder builder;
+    private SparseMethodContext sparseMethodContext;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, 0.5f);
+        parameters.put(N_POSTINGS_FIELD, 10);
+        parameters.put(CLUSTER_RATIO_FIELD, 0.3f);
+        parameters.put(ALGO_TRIGGER_DOC_COUNT_FIELD, 100);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, SEISMIC);
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        sparseMethodContext = SparseMethodContext.parse(methodMap);
+
+        builder = new SparseTokensFieldMapper.Builder("test_field");
+    }
+
+    public void testBuilder_withValidParameters_createsBuilder() {
+        assertNotNull(builder);
+        assertEquals("test_field", builder.name());
+    }
+
+    public void testBuilder_build_createsFieldMapper() {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        assertNotNull(mapper);
+        assertEquals("test_field", mapper.simpleName());
+        assertEquals(SparseTokensFieldMapper.CONTENT_TYPE, mapper.contentType());
+        assertEquals(sparseMethodContext, mapper.getSparseMethodContext());
+    }
+
+    public void testBuilder_withStoredTrue_setsStoredCorrectly() {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        builder.stored.setValue(true);
+
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        assertTrue(mapper.isStored());
+    }
+
+    public void testBuilder_withDocValuesFalse_setsDocValuesCorrectly() {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        builder.hasDocValues.setValue(false);
+
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        assertFalse(mapper.isHasDocValues());
+    }
+
+    public void testContentType_returnsCorrectValue() {
+        assertEquals("sparse_tokens", SparseTokensFieldMapper.CONTENT_TYPE);
+    }
+
+    public void testGetMergeBuilder_returnsNewBuilder() {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        SparseTokensFieldMapper.Builder mergeBuilder = (SparseTokensFieldMapper.Builder) mapper.getMergeBuilder();
+
+        assertNotNull(mergeBuilder);
+        assertEquals(mapper.simpleName(), mergeBuilder.name());
+    }
+
+    public void testClone_createsNewInstance() {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        SparseTokensFieldMapper cloned = mapper.clone();
+
+        assertNotNull(cloned);
+        assertNotSame(mapper, cloned);
+        assertEquals(mapper.simpleName(), cloned.simpleName());
+    }
+
+    public void testFieldType_returnsCorrectType() {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        SparseTokensFieldType fieldType = mapper.fieldType();
+
+        assertNotNull(fieldType);
+        assertTrue(fieldType instanceof SparseTokensFieldType);
+    }
+
+    public void testParseCreateField_withExternalValueSet_throwsException() throws IOException {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        ParseContext context = mock(ParseContext.class);
+        when(context.externalValueSet()).thenReturn(true);
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> { mapper.parseCreateField(context); });
+        assertEquals("[sparse_tokens] fields can't be used in multi-fields", exception.getMessage());
+    }
+
+    public void testParseCreateField_withInvalidToken_throwsException() throws IOException {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        ParseContext context = mock(ParseContext.class);
+        XContentParser parser = mock(XContentParser.class);
+        when(context.externalValueSet()).thenReturn(false);
+        when(context.parser()).thenReturn(parser);
+        when(parser.currentToken()).thenReturn(XContentParser.Token.VALUE_STRING);
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> { mapper.parseCreateField(context); });
+        assertTrue(exception.getMessage().contains("fields must be json objects"));
+    }
+
+    public void testSparseTypeParser_withValidInput_returnsBuilder() throws MapperParsingException {
+        SparseTokensFieldMapper.SparseTypeParser parser = new SparseTokensFieldMapper.SparseTypeParser();
+        Map<String, Object> node = new HashMap<>();
+        Map<String, Object> method = new HashMap<>();
+        method.put(NAME_FIELD, SEISMIC);
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, 0.5f);
+        method.put(PARAMETERS_FIELD, parameters);
+        node.put("method", method);
+
+        SparseTokensFieldMapper.Builder result = (SparseTokensFieldMapper.Builder) parser.parse(
+            "test_field",
+            node,
+            mock(Mapper.TypeParser.ParserContext.class)
+        );
+
+        assertNotNull(result);
+        assertEquals("test_field", result.name());
+    }
+
+    public void testSparseTypeParser_withoutMethod_throwsException() {
+        SparseTokensFieldMapper.SparseTypeParser parser = new SparseTokensFieldMapper.SparseTypeParser();
+        Map<String, Object> node = new HashMap<>();
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> {
+            parser.parse("test_field", node, mock(Mapper.TypeParser.ParserContext.class));
+        });
+        assertTrue(exception.getMessage().contains("requires [method] parameter"));
+    }
+
+    public void testSparseTypeParser_withNullMethodName_throwsException() {
+        // This test shows that line 252 of SparseTokensFieldMapper.java could never reach
+        SparseTokensFieldMapper.SparseTypeParser parser = new SparseTokensFieldMapper.SparseTypeParser();
+        Map<String, Object> node = new HashMap<>();
+        Map<String, Object> method = new HashMap<>();
+        method.put(NAME_FIELD, null); // null name
+        node.put("method", method);
+
+        NullPointerException exception = expectThrows(NullPointerException.class, () -> {
+            parser.parse("test_field", node, mock(Mapper.TypeParser.ParserContext.class));
+        });
+        assertTrue(exception.getMessage().contains("Cannot invoke \"String.isEmpty()\""));
+    }
+
+    public void testSparseTypeParser_withoutMethodName_throwsException() {
+        SparseTokensFieldMapper.SparseTypeParser parser = new SparseTokensFieldMapper.SparseTypeParser();
+        Map<String, Object> node = new HashMap<>();
+        Map<String, Object> method = new HashMap<>();
+        node.put("method", method);
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> {
+            parser.parse("test_field", node, mock(Mapper.TypeParser.ParserContext.class));
+        });
+        assertTrue(exception.getMessage().contains("name needs to be set"));
+    }
+
+    public void testSparseTypeParser_withUnsupportedMethod_throwsException() {
+        SparseTokensFieldMapper.SparseTypeParser parser = new SparseTokensFieldMapper.SparseTypeParser();
+        Map<String, Object> node = new HashMap<>();
+        Map<String, Object> method = new HashMap<>();
+        method.put(NAME_FIELD, "unsupported_method");
+        node.put("method", method);
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> {
+            parser.parse("test_field", node, mock(Mapper.TypeParser.ParserContext.class));
+        });
+        assertTrue(exception.getMessage().contains("is not supported"));
+    }
+
+    public void testSparseTypeParser_withInvalidParameters_throwsException() {
+        SparseTokensFieldMapper.SparseTypeParser parser = new SparseTokensFieldMapper.SparseTypeParser();
+        Map<String, Object> node = new HashMap<>();
+        Map<String, Object> method = new HashMap<>();
+        method.put(NAME_FIELD, SEISMIC);
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, -1.0f);
+        method.put(PARAMETERS_FIELD, parameters);
+        node.put("method", method);
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> {
+            parser.parse("test_field", node, mock(Mapper.TypeParser.ParserContext.class));
+        });
+        assertTrue(exception.getMessage().contains("Validation Failed"));
+    }
+
+    public void testDefaults_fieldTypeAttributes() {
+        Map<String, String> fieldTypeAttrs = SparseTokensFieldMapper.Defaults.FIELD_TYPE.getAttributes();
+        assertTrue(fieldTypeAttrs.containsKey("sparse_tokens_field"));
+        assertEquals("true", fieldTypeAttrs.get("sparse_tokens_field"));
+
+        Map<String, String> tokenFieldTypeAttrs = SparseTokensFieldMapper.Defaults.TOKEN_FIELD_TYPE.getAttributes();
+        assertTrue(tokenFieldTypeAttrs.containsKey("sparse_tokens_field"));
+        assertEquals("true", tokenFieldTypeAttrs.get("sparse_tokens_field"));
+    }
+
+    public void testBuilder_getParameters_returnsCorrectParameters() {
+        assertEquals(3, builder.getParameters().size());
+    }
+
+    public void testParseCreateField_withValidJsonObject_parsesSuccessfully() throws IOException {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        ParseContext context = mock(ParseContext.class);
+        XContentParser parser = mock(XContentParser.class);
+        ParseContext.Document doc = mock(ParseContext.Document.class);
+
+        when(context.externalValueSet()).thenReturn(false);
+        when(context.parser()).thenReturn(parser);
+        when(context.doc()).thenReturn(doc);
+        when(parser.currentToken()).thenReturn(XContentParser.Token.START_OBJECT);
+        when(parser.nextToken()).thenReturn(XContentParser.Token.FIELD_NAME)
+            .thenReturn(XContentParser.Token.VALUE_NUMBER)
+            .thenReturn(XContentParser.Token.END_OBJECT);
+        when(parser.currentName()).thenReturn("feature1");
+        when(parser.floatValue(true)).thenReturn(0.5f);
+        when(doc.getByKey(any())).thenReturn(null);
+
+        mapper.parseCreateField(context);
+
+        verify(doc, times(1)).add(any()); // Only SparseTokensField is added to doc
+        verify(doc, times(1)).addWithKey(any(), any()); // FeatureField is added with key
+    }
+
+    public void testParseCreateField_withNullValue_ignoresFeature() throws IOException {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        ParseContext context = mock(ParseContext.class);
+        XContentParser parser = mock(XContentParser.class);
+        ParseContext.Document doc = mock(ParseContext.Document.class);
+
+        when(context.externalValueSet()).thenReturn(false);
+        when(context.parser()).thenReturn(parser);
+        when(context.doc()).thenReturn(doc);
+        when(parser.currentToken()).thenReturn(XContentParser.Token.START_OBJECT);
+        when(parser.nextToken()).thenReturn(XContentParser.Token.FIELD_NAME)
+            .thenReturn(XContentParser.Token.VALUE_NULL)
+            .thenReturn(XContentParser.Token.END_OBJECT);
+        when(parser.currentName()).thenReturn("feature1");
+
+        mapper.parseCreateField(context);
+
+        verify(doc, times(1)).add(any()); // Only SparseTokensField
+    }
+
+    public void testParseCreateField_withDuplicateFeature_throwsException() throws IOException {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        ParseContext context = mock(ParseContext.class);
+        XContentParser parser = mock(XContentParser.class);
+        ParseContext.Document doc = mock(ParseContext.Document.class);
+
+        when(context.externalValueSet()).thenReturn(false);
+        when(context.parser()).thenReturn(parser);
+        when(context.doc()).thenReturn(doc);
+        when(parser.currentToken()).thenReturn(XContentParser.Token.START_OBJECT);
+        when(parser.nextToken()).thenReturn(XContentParser.Token.FIELD_NAME).thenReturn(XContentParser.Token.VALUE_NUMBER);
+        when(parser.currentName()).thenReturn("feature1");
+        when(parser.floatValue(true)).thenReturn(0.5f);
+        when(doc.getByKey(any())).thenReturn(mock(org.apache.lucene.document.Field.class));
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> { mapper.parseCreateField(context); });
+        assertTrue(exception.getMessage().contains("do not support indexing multiple values"));
+    }
+
+    public void testParseCreateField_withInvalidTokenType_throwsException() throws IOException {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        ParseContext context = mock(ParseContext.class);
+        XContentParser parser = mock(XContentParser.class);
+        ParseContext.Document doc = mock(ParseContext.Document.class);
+
+        when(context.externalValueSet()).thenReturn(false);
+        when(context.parser()).thenReturn(parser);
+        when(context.doc()).thenReturn(doc);
+        when(parser.currentToken()).thenReturn(XContentParser.Token.START_OBJECT);
+        when(parser.nextToken()).thenReturn(XContentParser.Token.FIELD_NAME).thenReturn(XContentParser.Token.START_ARRAY);
+        when(parser.currentName()).thenReturn("feature1");
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> { mapper.parseCreateField(context); });
+        assertTrue(exception.getMessage().contains("got unexpected token"));
+    }
+
+    public void testSparseMethodContextSerialization_withValidContext_serializesCorrectly() throws Exception {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+            new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        // Use XContentFactory to create a real XContentBuilder
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+
+        // This will trigger the serializer code: b.startObject(n); v.toXContent(b, ToXContent.EMPTY_PARAMS); b.endObject();
+        mapper.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+
+        xContentBuilder.endObject();
+        String result = xContentBuilder.toString();
+
+        // Verify the serialization contains the method object
+        assertTrue(result.contains("method"));
+        assertTrue(result.contains(SEISMIC));
+    }
+
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/testsPrepareUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/testsPrepareUtils.java
@@ -29,6 +29,8 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.Version;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.mapper.ContentPath;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -355,5 +357,13 @@ public class testsPrepareUtils {
                 return VectorSimilarityFunction.EUCLIDEAN;
             }
         };
+    }
+
+    public static Settings prepareIndexSettings() {
+        return Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0).build();
+    }
+
+    public static ContentPath prepareContentPath() {
+        return new ContentPath();
     }
 }


### PR DESCRIPTION
### Description
This PR creates unit tests for `org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldMapper` class. It reaches 98% coverage.

I tried to test
```
if (context.getName() == null) {
    throw new MapperParsingException("[" + CONTENT_TYPE + "] requires [method.name] parameter");
}
```
of `org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldMapper`, but I found that if `name` is `null`, it would first trigger
```
if (name.isEmpty()) {
    throw new MapperParsingException(NAME_FIELD + " needs to be set");
}
```
of `org.opensearch.neuralsearch.sparse.mapper.SparseMethodContext` first and throw an `NullPointerException` as it cannot invoke `name.isEmpty()`.

Or, I previously tried an empty string instead of `null`, then it would raise `MapperParsingException[name needs to be set]`. We still cannot reach `requires [method.name] parameter`.

You can find this situation by executing `testSparseTypeParser_withNullMethodName_throwsException` inside this SparseTokensFieldMapperTests.java file.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
