### PR TITLE
[Unit Tests] SparseTokensFieldType

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldTypeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldTypeTests.java
@@ -42,11 +42,10 @@ public class SparseTokensFieldTypeTests extends AbstractSparseTestBase {
         methodMap.put(NAME_FIELD, SEISMIC);
         methodMap.put(PARAMETERS_FIELD, parameters);
         sparseMethodContext = SparseMethodContext.parse(methodMap);
-
-        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
     }
 
     public void testConstructor_withValidParameters_createsFieldType() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
         assertNotNull(fieldType);
         assertEquals("test_field", fieldType.name());
         assertEquals(sparseMethodContext, fieldType.getSparseMethodContext());
@@ -62,10 +61,12 @@ public class SparseTokensFieldTypeTests extends AbstractSparseTestBase {
     }
 
     public void testTypeName_returnsCorrectType() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
         assertEquals("sparse_tokens", fieldType.typeName());
     }
 
     public void testValueFetcher_withNullFormat_returnsSourceValueFetcher() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
         QueryShardContext context = mock(QueryShardContext.class);
         SearchLookup searchLookup = mock(SearchLookup.class);
 
@@ -73,6 +74,7 @@ public class SparseTokensFieldTypeTests extends AbstractSparseTestBase {
     }
 
     public void testValueFetcher_withFormat_throwsException() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
         QueryShardContext context = mock(QueryShardContext.class);
         SearchLookup searchLookup = mock(SearchLookup.class);
 
@@ -83,6 +85,7 @@ public class SparseTokensFieldTypeTests extends AbstractSparseTestBase {
     }
 
     public void testTermQuery_throwsIllegalArgumentException() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
         QueryShardContext context = mock(QueryShardContext.class);
 
         IllegalArgumentException exception = expectThrows(
@@ -93,6 +96,7 @@ public class SparseTokensFieldTypeTests extends AbstractSparseTestBase {
     }
 
     public void testExistsQuery_throwsIllegalArgumentException() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
         QueryShardContext context = mock(QueryShardContext.class);
 
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> { fieldType.existsQuery(context); });
@@ -100,6 +104,7 @@ public class SparseTokensFieldTypeTests extends AbstractSparseTestBase {
     }
 
     public void testFielddataBuilder_throwsIllegalArgumentException() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
             fieldType.fielddataBuilder("test_index", () -> mock(SearchLookup.class));
         });
@@ -107,6 +112,7 @@ public class SparseTokensFieldTypeTests extends AbstractSparseTestBase {
     }
 
     public void testGetters_returnCorrectValues() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
         assertEquals(sparseMethodContext, fieldType.getSparseMethodContext());
         assertFalse(fieldType.isStored());
         assertTrue(fieldType.isHasDocValues());
@@ -123,6 +129,7 @@ public class SparseTokensFieldTypeTests extends AbstractSparseTestBase {
     }
 
     public void testTermQuery_withDifferentValueTypes_throwsException() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
         QueryShardContext context = mock(QueryShardContext.class);
 
         // Test with different value types
@@ -142,11 +149,13 @@ public class SparseTokensFieldTypeTests extends AbstractSparseTestBase {
     }
 
     public void testFieldTypeInheritance_extendsCorrectClass() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
         assertTrue(fieldType instanceof org.opensearch.index.mapper.MappedFieldType);
     }
 
     public void testFieldTypeProperties_inheritedFromParent() {
         // Test inherited properties from MappedFieldType
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
         assertEquals("test_field", fieldType.name());
         assertFalse(fieldType.isSearchable()); // Set to false in constructor
         assertFalse(fieldType.isStored()); // Our stored parameter


### PR DESCRIPTION
### Description
This PR creates unit tests for `org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldType` class. It achieves 100% coverage.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
